### PR TITLE
Preserve product title in URL

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,6 +4,7 @@
 
 var regexAmzn = new RegExp(/^(https?:\/\/)?([\da-z\.-]+)\.amazon\.([\da-z\.-]+).*$/);
 var code;
+var prsvTitle;
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
 	//Show the link icon for only Amazon pages
 	var url = tab.url;
@@ -16,6 +17,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
 function theThings(doIt) {
 	console.log(doIt.amzncode);
 	code = doIt.amzncode || "jimmysweetblog-20";
+	prsvTitle = doIt.prsvTitle;
 }
 
 
@@ -23,7 +25,7 @@ chrome.pageAction.onClicked.addListener(function (tab) {
 	chrome.storage.sync.get(theThings);
 
 	// build shortlink 
-	var goodLink = 'https://' + getAMZN(tab.url, 'PREFIX') + '.amazon.' + getAMZN(tab.url, 'COUNTRY') + getAMZN(tab.url, 'PRODUCT') + (code ? '?tag=' + code : '');
+	var goodLink = 'https://' + getAMZN(tab.url, 'PREFIX') + '.amazon.' + getAMZN(tab.url, 'COUNTRY') + getAMZN(tab.url, 'TITLE') + getAMZN(tab.url, 'PRODUCT') + (code ? '?tag=' + code : '');
 
 	copyToClipboard(goodLink);
 	chrome.tabs.update({
@@ -48,7 +50,7 @@ chrome.pageAction.onClicked.addListener(function (tab) {
 // http://stackoverflow.com/questions/1764605/scrape-asin-from-amazon-url-using-javascript
 // http://en.wikipedia.org/wiki/Amazon_Standard_Identification_Number
 function getAMZN(url, target) {
-	var regexProduct = new RegExp(/^(https?:\/\/)?([\da-z\.-]+)\.amazon\.([\da-z\.-]+)\/?.*\/(exec\/obidos\/tg\/detail\/-|gp\/product|o\/ASIN|dp|dp\/product|exec\/obidos\/asin)\/(\w{10}).*$/);
+	var regexProduct = new RegExp(/^(https?:\/\/)?([\da-z\.-]+)\.amazon\.([\da-z\.-]+)(\/.+)?\/(exec\/obidos\/tg\/detail\/-|gp\/product|o\/ASIN|dp|dp\/product|exec\/obidos\/asin)\/(\w{10}).*$/);
 	var regexSearch = new RegExp(/^(https?:\/\/)?([\da-z\.-]+)\.amazon\.([\da-z\.-]+)\/s\/(ref=.*).*%3D(.+)&field-keywords=([^&]*)(?:&.*)?$/);
 
 	p = url.match(regexProduct);
@@ -56,7 +58,14 @@ function getAMZN(url, target) {
 	s = url.match(regexSearch);
 	if (p) {
 		if (target == 'PRODUCT') {
-			return '/dp/' + p[5];
+			return '/dp/' + p[6];
+		} else if (target == 'TITLE') {
+			if (prsvTitle) {
+				return p[4];
+			}
+			else {
+				return '';
+			}
 		} else if (target == 'COUNTRY') {
 			return p[3];
 		} else if (target == 'PREFIX') {

--- a/settings/options.html
+++ b/settings/options.html
@@ -12,6 +12,12 @@
 				<input id="amzncode">
 			</label>
 		</p>
+		<p>
+			<label>
+				Preserve product title in URL
+				<input id="prsvtitle" type="checkbox">
+			</label>
+		</p>
 	</form>
 	<script src="options.js"></script>
 </body>

--- a/settings/options.js
+++ b/settings/options.js
@@ -1,7 +1,8 @@
 function saveOptions() {
 
 	chrome.storage.sync.set({
-		amzncode: document.querySelector("#amzncode").value || "jimmysweetblog-20"
+		amzncode: document.querySelector("#amzncode").value || "jimmysweetblog-20",
+        prsvtitle: document.querySelector("#prsvtitle").checked
 	});
 }
 
@@ -9,6 +10,7 @@ function restoreOptions() {
 
 	function setCurrentChoice(result) {
 		document.querySelector("#amzncode").value = result.amzncode || "jimmysweetblog-20";
+        document.querySelector("#prsvtitle").checked = result.prsvtitle;
 	}
 
 	function onError(error) {
@@ -21,3 +23,4 @@ function restoreOptions() {
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.getElementById('amzncode').addEventListener("input", saveOptions);
+document.getElementById('prsvtitle').addEventListener("input", saveOptions);


### PR DESCRIPTION
It would be cool if there is an option to preserve the product title in the URL, for example if

`https://www.amazon.com/Tonight-Oliver-Presents-Marlon-Bundo/dp/145217380X/ref=sr_1_1/133-0760154-8368905?ie=UTF8&qid=1526767491&sr=8-1&keywords=last+week+tonight+marlon+bundo`

would become 

`https://www.amazon.com/Tonight-Oliver-Presents-Marlon-Bundo/dp/145217380X?tag=jimmysweetblog-20`

instead of

`https://www.amazon.com/dp/145217380X?tag=jimmysweetblog-20`.

This PR is just a first guess how that could look like. Since I haven't set up any kind of development environment for Chrome/Firefox extensions, I have written that completely blindly without any kind of testing.